### PR TITLE
Redirect notifications away from dev mailing list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,8 +13,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
+
 # see https://s.apache.org/asfyaml
+
 github:
   description: "Apache Maven Project Utils"
   homepage: https://maven.apache.org/shared/maven-project-utils/
@@ -23,3 +24,9 @@ github:
     - build-management
     - maven-shared
     - maven
+
+notifications:
+  commits: commits@maven.apache.org
+  issues: issues@maven.apache.org
+  pullrequests: issues@maven.apache.org
+  jira_options: link label comment


### PR DESCRIPTION
Otherwise, GitHub activities overwhelm the dev@ mailing list.